### PR TITLE
MISC - Remove "Check before launch" step and disable the JavadocMethod rule

### DIFF
--- a/config/checkstyle/rules.xml
+++ b/config/checkstyle/rules.xml
@@ -211,6 +211,7 @@
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
+        <!--
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
@@ -220,6 +221,7 @@
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
+        -->
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
             <message key="name.invalidPattern"

--- a/note/checkstyle-sample-note.md
+++ b/note/checkstyle-sample-note.md
@@ -222,19 +222,7 @@ Check that it's working by writing some poorly styled code:
 
     FAILURE: Build failed with an exception.
 
-### Step 5 - Check before launch
-
-Set the code style check to run before launching the app:
-
-Open settings from 'Build -> Edit Configurations...' (see below) 'Before Launch' option, click the plus icon, select 'Gradle-aware Make' type in the popup dialog and input ':app:checkstyle' task.
-
-![](./art/3_config_check_before_launch.png)
-
-After that, when you click 'Run' button, it will fail if the code style check fails:
-
-![](./art/4_check_before_launch.png)
-
-### Step 6 - Check before Commit
+### Step 5 - Check before Commit
 
 In order to prevent poorly styled code from going into Git you can use a 'pre-commit' hook.
 


### PR DESCRIPTION
After the experience, I found check before launch setting affects to develop efficiency too much, and JavadocMethod rule is too strict for us. JavadocMethod rule asks you to comment all public method that has no annotation.